### PR TITLE
Add Multiplication loops

### DIFF
--- a/Brainfuck Interpreter/interpreter.cpp
+++ b/Brainfuck Interpreter/interpreter.cpp
@@ -302,4 +302,3 @@ bool operator!=(Instruction::Type x, const Instruction& y)
 {
 	return y != x;
 }
-

--- a/Brainfuck Interpreter/interpreter.cpp
+++ b/Brainfuck Interpreter/interpreter.cpp
@@ -46,8 +46,6 @@ void Instruction::Execute() const
 	case Type::Reset:
 		*Parent->Pointer = 0;
 		break;
-	case Type::Nop:
-		break;
 	}
 }
 

--- a/Brainfuck Interpreter/interpreter.cpp
+++ b/Brainfuck Interpreter/interpreter.cpp
@@ -5,6 +5,7 @@
 #include <utility>
 #include <string>
 #include <stack>
+#include <algorithm>
 
 Instruction::Instruction(Type x, std::intptr_t y) : Command(x), Data(y) { }
 
@@ -17,14 +18,7 @@ void Instruction::Execute() const
 	switch (Command)
 	{
 	case Type::MovePointer:
-		Parent->Cells.Index += Data;
-
-		for (;Parent->Cells.Index < Parent->Cells.Limits.first; --Parent->Cells.Limits.first)
-			Parent->Cells.Data.emplace_front(0);
-		for (;Parent->Cells.Index > Parent->Cells.Limits.second; ++Parent->Cells.Limits.second)
-			Parent->Cells.Data.emplace_back(0);
-
-		std::advance(Parent->Pointer, Data);
+		AdvancePointer(Data);
 		break;
 	case Type::Addition:
 		*Parent->Pointer += Data;
@@ -46,6 +40,17 @@ void Instruction::Execute() const
 	case Type::Reset:
 		*Parent->Pointer = 0;
 		break;
+	case Type::Multiplication:
+		// The first half of the Value contains
+		// the offset and the second the multiplication value
+		auto Offset = Data >> (sizeof(std::ptrdiff_t) * 4);
+		auto Value1 = Data & static_cast<std::intptr_t>(std::pow(2, sizeof(std::ptrdiff_t) * 4) - 1);
+		auto Value2 = *Parent->Pointer;
+
+		AdvancePointer(Offset);
+		*Parent->Pointer += Value1 * Value2;
+		std::advance(Parent->Pointer, -Offset);
+		break;
 	}
 }
 
@@ -62,6 +67,18 @@ void Instruction::Set(Instruction* x)
 std::pair<Instruction::Type, std::intptr_t> Instruction::Query() const
 {
 	return std::make_pair(Command, Data);
+}
+
+void Instruction::AdvancePointer(std::ptrdiff_t Offset)
+{
+	Parent->Cells.Index += Offset;
+
+	for (;Parent->Cells.Index < Parent->Cells.Limits.first; --Parent->Cells.Limits.first)
+		Parent->Cells.Data.emplace_front(0);
+	for (;Parent->Cells.Index > Parent->Cells.Limits.second; ++Parent->Cells.Limits.second)
+		Parent->Cells.Data.emplace_back(0);
+
+	std::advance(Parent->Pointer, Offset);
 }
 
 void Instruction::SetParent(ProgramData* Adopter)
@@ -170,8 +187,66 @@ ProgramData::ProgramData(const char* const Path)
 					}
 				}
 
+				Instruction* EndPointer = std::data(Text) + std::size(Text);
+
+				/*
+				*	If this is loop only contains MovePointer
+				*	and Addition instructions, then we should be
+				*	able to replace it with Multiplication instructions
+				*/
+				if (std::all_of(std::next(JumpTable.top()), EndPointer, [](const Instruction& x)
+				{ return x == Instruction::Type::Addition || x == Instruction::Type::MovePointer; }))
+				{
+					std::intptr_t Offset = 0;
+					// Offset, Value
+					std::list<std::pair<std::intptr_t, std::intptr_t>> Operations;
+
+					for (auto Iterator = std::next(JumpTable.top()); Iterator != EndPointer; ++Iterator)
+					{
+						if (*Iterator == Instruction::Type::MovePointer)
+							Offset += Iterator->Query().second;
+						else if (*Iterator == Instruction::Type::Addition)
+							Operations.emplace_back(Offset, Iterator->Query().second);
+					}
+
+					/*
+					*	Make sure the Pointer ends up were it started
+					*	and only 1 was subtracted from Cell #0
+					*/
+					if (Offset == 0)
+					{
+						if (std::count_if(std::cbegin(Operations), std::cend(Operations), [](std::pair<std::intptr_t, std::intptr_t> x)
+						{ return x.first == 0; }) == 1)
+						{
+							auto Cell0 = std::find_if(std::cbegin(Operations), std::cend(Operations), [](std::pair<std::intptr_t, std::intptr_t> x)
+							{ return x.first == 0; });
+
+							if (Cell0->second == -1)
+							{
+								/*
+								*	We cannot use std::vector::erase because
+								*	we have a pointer, not an iterator, so
+								*	we have to remove the elements one at a time
+								*/
+								while (JumpTable.top() <= &Text.back())
+									Text.pop_back();
+								JumpTable.pop();
+								
+								for (const auto& Operation : Operations)
+								{
+									if (Operation.first)
+										Text.emplace_back(Instruction::Type::Multiplication, Operation.first << (sizeof(std::ptrdiff_t) * 4) | Operation.second);
+								}
+								Text.emplace_back(Instruction::Type::Reset);
+
+								break;
+							}
+						}
+					}
+				}
+
 				Text.emplace_back(Instruction::Type::LoopEnd, std::next(JumpTable.top()));
-				JumpTable.top()->Set(std::data(Text) + std::size(Text));
+				JumpTable.top()->Set(EndPointer);
 				JumpTable.pop();
 
 				Last = Instruction::Type::LoopEnd;

--- a/Brainfuck Interpreter/interpreter.cpp
+++ b/Brainfuck Interpreter/interpreter.cpp
@@ -238,6 +238,7 @@ ProgramData::ProgramData(const char* const Path)
 										Text.emplace_back(Instruction::Type::Multiplication, Operation.first, Operation.second);
 								}
 								Text.emplace_back(Instruction::Type::Reset);
+								Last = Instruction::Type::Reset;
 
 								break;
 							}

--- a/Brainfuck Interpreter/interpreter.cpp
+++ b/Brainfuck Interpreter/interpreter.cpp
@@ -14,6 +14,7 @@ Instruction::Instruction(Type x, Instruction* y) : Command(x), Data(reinterpret_
 Instruction::Instruction(Type x, std::int32_t y, std::int32_t z) : Command(x), SmallData{ y, z } { }
 
 ProgramData* Instruction::Parent = nullptr;
+std::intptr_t Instruction::TemporaryValue = 0;
 
 void Instruction::Execute() const
 {
@@ -41,6 +42,9 @@ void Instruction::Execute() const
 		break;
 	case Type::Reset:
 		*Parent->Pointer = 0;
+		break;
+	case Type::Store:
+		TemporaryValue = *Parent->Pointer;
 		break;
 	case Type::Multiplication:
 		// The first half of the Value contains

--- a/Brainfuck Interpreter/interpreter.cpp
+++ b/Brainfuck Interpreter/interpreter.cpp
@@ -48,7 +48,8 @@ void Instruction::Execute() const
 		TemporaryValue = *Parent->Pointer;
 		break;
 	case Type::Multiplication:
-		*Parent->Pointer += Data * TemporaryValue;
+		AdvancePointer(SmallData[0]);
+		*Parent->Pointer += SmallData[1] * TemporaryValue;
 		break;
 	}
 }
@@ -242,12 +243,9 @@ ProgramData::ProgramData(const char* const Path)
 								Text.emplace_back(Instruction::Type::Reset);
 
 								for (const auto& Operation : Operations)
-								{
-									Text.emplace_back(Instruction::Type::MovePointer, Operation.first);
-									Text.emplace_back(Instruction::Type::Multiplication, Operation.second);
-								}
+									Text.emplace_back(Instruction::Type::Multiplication, Operation.first, Operation.second);
 
-								Text.emplace_back(Instruction::Type::MovePointer, -std::accumulate(Operations.cbegin(), Operations.cend(), 0,
+								Text.emplace_back(Instruction::Type::MovePointer, -std::accumulate(std::cbegin(Operations), std::cend(Operations), 0,
 									[](intptr_t x, std::pair<std::intptr_t, std::intptr_t> y) { return x + y.first; }));
 								Last = Instruction::Type::MovePointer;
 

--- a/Brainfuck Interpreter/interpreter.cpp
+++ b/Brainfuck Interpreter/interpreter.cpp
@@ -231,12 +231,10 @@ ProgramData::ProgramData(const char* const Path)
 								while (JumpTable.top() <= &Text.back())
 									Text.pop_back();
 								JumpTable.pop();
-								
+								Operations.erase(Cell0);
+
 								for (const auto& Operation : Operations)
-								{
-									if (Operation.first)
-										Text.emplace_back(Instruction::Type::Multiplication, Operation.first, Operation.second);
-								}
+									Text.emplace_back(Instruction::Type::Multiplication, Operation.first, Operation.second);
 								Text.emplace_back(Instruction::Type::Reset);
 								Last = Instruction::Type::Reset;
 

--- a/Brainfuck Interpreter/interpreter.cpp
+++ b/Brainfuck Interpreter/interpreter.cpp
@@ -49,7 +49,7 @@ void Instruction::Execute() const
 
 		AdvancePointer(SmallData[0]);
 		*Parent->Pointer += SmallData[1] * Value2;
-		std::advance(Parent->Pointer, -SmallData[0]);
+		AdvancePointer(-SmallData[0]);
 		break;
 	}
 }

--- a/Brainfuck Interpreter/interpreter.cpp
+++ b/Brainfuck Interpreter/interpreter.cpp
@@ -207,3 +207,23 @@ void ProgramData::Run()
 	while (InstructionPointer->Query().first != Instruction::Type::Stop)
 		InstructionPointer++->Execute();
 }
+
+bool operator==(const Instruction& x, Instruction::Type y)
+{
+	return x.Query().first == y;
+}
+
+bool operator==(Instruction::Type x, const Instruction& y)
+{
+	return y == x;
+}
+
+bool operator!=(const Instruction& x, Instruction::Type y)
+{
+	return !(x == y);
+}
+bool operator!=(Instruction::Type x, const Instruction& y)
+{
+	return y != x;
+}
+

--- a/Brainfuck Interpreter/interpreter.cpp
+++ b/Brainfuck Interpreter/interpreter.cpp
@@ -41,11 +41,10 @@ void Instruction::Execute() const
 		if (*Parent->Pointer != 0)
 			Parent->InstructionPointer = reinterpret_cast<Instruction*>(Data);
 		break;
-	case Type::Reset:
-		*Parent->Pointer = 0;
-		break;
 	case Type::Store:
 		TemporaryValue = *Parent->Pointer;
+	case Type::Reset:
+		*Parent->Pointer = 0;
 		break;
 	case Type::Multiplication:
 		AdvancePointer(SmallData[0]);
@@ -240,7 +239,6 @@ ProgramData::ProgramData(const char* const Path)
 								Operations.erase(Cell0);
 
 								Text.emplace_back(Instruction::Type::Store);
-								Text.emplace_back(Instruction::Type::Reset);
 
 								for (const auto& Operation : Operations)
 									Text.emplace_back(Instruction::Type::Multiplication, Operation.first, Operation.second);

--- a/Brainfuck Interpreter/interpreter.hpp
+++ b/Brainfuck Interpreter/interpreter.hpp
@@ -34,7 +34,7 @@ public:
 class Instruction
 {
 public:
-	enum class Type { Nop, MovePointer, Addition, Input, Output, LoopStart, LoopEnd, Reset, Stop };
+	enum class Type { Nop, MovePointer, Addition, Input, Output, LoopStart, LoopEnd, Reset, Multiplication, Stop };
 
 	explicit Instruction(Type, std::intptr_t = 0);
 	Instruction(Type, Instruction*);
@@ -43,6 +43,8 @@ public:
 	void Modify(std::intptr_t);
 	void Set(Instruction*);
 	std::pair<Type, std::intptr_t> Query() const;
+
+	static void AdvancePointer(std::ptrdiff_t Offset);
 
 	static void SetParent(ProgramData*);
 	static void Orphan(ProgramData*);

--- a/Brainfuck Interpreter/interpreter.hpp
+++ b/Brainfuck Interpreter/interpreter.hpp
@@ -52,3 +52,9 @@ private:
 	std::intptr_t Data;
 	static ProgramData* Parent;
 };
+
+inline bool operator==(const Instruction& x, Instruction::Type y);
+inline bool operator==(Instruction::Type x, const Instruction& y);
+
+inline bool operator!=(const Instruction& x, Instruction::Type y);
+inline bool operator!=(Instruction::Type x, const Instruction& y);

--- a/Brainfuck Interpreter/interpreter.hpp
+++ b/Brainfuck Interpreter/interpreter.hpp
@@ -38,6 +38,7 @@ public:
 
 	explicit Instruction(Type, std::intptr_t = 0);
 	Instruction(Type, Instruction*);
+	Instruction(Type, std::int32_t Offset, std::int32_t Value);
 
 	void Execute() const;
 	void Modify(std::intptr_t);
@@ -51,7 +52,11 @@ public:
 
 private:
 	const Type Command;
-	std::intptr_t Data;
+	union
+	{
+		std::intptr_t Data;
+		std::int32_t SmallData[2];
+	};
 	static ProgramData* Parent;
 };
 

--- a/Brainfuck Interpreter/interpreter.hpp
+++ b/Brainfuck Interpreter/interpreter.hpp
@@ -34,7 +34,7 @@ public:
 class Instruction
 {
 public:
-	enum class Type { Nop, MovePointer, Addition, Input, Output, LoopStart, LoopEnd, Reset, Multiplication, Stop };
+	enum class Type { Nop, MovePointer, Addition, Input, Output, LoopStart, LoopEnd, Reset, Multiplication, Store, Stop };
 
 	explicit Instruction(Type, std::intptr_t = 0);
 	Instruction(Type, Instruction*);
@@ -57,7 +57,9 @@ private:
 		std::intptr_t Data;
 		std::int32_t SmallData[2];
 	};
+
 	static ProgramData* Parent;
+	static std::intptr_t TemporaryValue;
 };
 
 inline bool operator==(const Instruction& x, Instruction::Type y);


### PR DESCRIPTION
Loops that only move the pointer and perform addition are optimized into multiplications instructions.
Large improvements in performance were observed in long.bf (250%).
