### PR TITLE
Improve interpreter performance

### DIFF
--- a/Brainfuck Interpreter/interpreter.cpp
+++ b/Brainfuck Interpreter/interpreter.cpp
@@ -17,7 +17,7 @@ Instruction::value_type Instruction::TemporaryValue = 0;
 Memory::Front_tag Memory::Front{};
 Memory::Back_tag Memory::Back{};
 
-const std::array<std::function<void(Instruction*)>, 13> Instruction::FunctionPointers
+const std::array<void(*)(Instruction*), 13> Instruction::FunctionPointers
 {
 	[](Instruction* x) {},
 	[](Instruction* x) { std::advance(Parent->DataPointer, *x->Data); },

--- a/Brainfuck Interpreter/interpreter.cpp
+++ b/Brainfuck Interpreter/interpreter.cpp
@@ -1,5 +1,4 @@
 #include "interpreter.hpp"
-#include "io.hpp"
 
 #include <iterator>
 #include <utility>
@@ -8,61 +7,15 @@
 #include <algorithm>
 #include <numeric>
 
-Instruction::Instruction(Type x, Instruction* y) : Command(x), Pointer(y) { }
+Instruction::Instruction(Type x, Instruction* y) : Command(x), Pointer(y), FunctionPointer(FunctionPointers[Command]) { }
 
-Instruction::Instruction(Type x, value_type y, value_type z) : Command(x), Data{ y, z } { }
+Instruction::Instruction(Type x, value_type y, value_type z) : Command(x), Data{ y, z }, FunctionPointer(FunctionPointers[Command]) { }
 
 ProgramData* Instruction::Parent = nullptr;
 Instruction::value_type Instruction::TemporaryValue = 0;
 
 Memory::Front_tag Memory::Front{};
 Memory::Back_tag Memory::Back{};
-
-void Instruction::Execute() const
-{
-	switch (Command)
-	{
-	case Type::MovePointer:
-		std::advance(Parent->DataPointer, *Data);
-		break;
-	case Type::Addition:
-		*Parent->DataPointer += *Data;
-		break;
-	case Type::Input:
-		*Parent->DataPointer = InputByte();
-		break;
-	case Type::Output:
-		OutputByte(*Parent->DataPointer);
-		break;
-	case Type::LoopStart:
-		if (*Parent->DataPointer == 0)
-			Parent->InstructionPointer = Pointer;
-		break;
-	case Type::LoopEnd:
-		if (*Parent->DataPointer != 0)
-			Parent->InstructionPointer = Pointer;
-		break;
-	case Type::Store:
-		TemporaryValue = *Parent->DataPointer;
-		*Parent->DataPointer = 0;
-		break;
-	case Type::Reset:
-		std::fill_n(Parent->DataPointer, Data[0], 0);
-		std::advance(Parent->DataPointer, Data[1]);
-		break;
-	case Type::Multiplication:
-		std::advance(Parent->DataPointer, Data[0]);
-		*Parent->DataPointer += Data[1] * TemporaryValue;
-		break;
-	case Type::Seek:
-		while (*Parent->DataPointer)
-			std::advance(Parent->DataPointer, *Data);
-		break;
-	case Type::Set:
-		*Parent->DataPointer = *Data;
-		break;
-	}
-}
 
 void Instruction::SetParent(ProgramData* Adopter)
 {
@@ -324,7 +277,7 @@ ProgramData::~ProgramData()
 void ProgramData::Run()
 {
 	while (InstructionPointer->Command != Instruction::Type::Stop)
-		InstructionPointer++->Execute();
+		InstructionPointer++->FunctionPointer();
 }
 
 bool Instruction::operator==(Type y) const

--- a/Brainfuck Interpreter/interpreter.hpp
+++ b/Brainfuck Interpreter/interpreter.hpp
@@ -7,7 +7,6 @@
 #include <array>
 #include <cstdint>
 #include <iterator>
-#include <functional>
 
 class Memory_iterator : public std::iterator<std::random_access_iterator_tag, char>
 {
@@ -104,6 +103,7 @@ public:
 	static void Orphan(ProgramData*);
 
 	const Type Command;
+	void(*FunctionPointer)(Instruction*);
 	union
 	{
 		value_type Data[2];
@@ -113,8 +113,7 @@ public:
 	static ProgramData* Parent;
 	static value_type TemporaryValue;
 
-	static const std::array<std::function<void(Instruction*)>, 13> FunctionPointers;
-	const std::function<void(Instruction*)> FunctionPointer;
+	static const std::array<void(*)(Instruction*), 13> FunctionPointers;
 };
 
 inline bool operator==(Instruction::Type x, const Instruction& y);


### PR DESCRIPTION
- Migrate the interpreter from a `switch` to a subroutine threading model, greatly improving performance.
- Improve the performance of `Memory_iterator`
